### PR TITLE
chore: updated .prettierrc.json to use "auto" for endOfLine

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,


### PR DESCRIPTION
### Description
This pull request resolves a compatibility issue related to line endings (endOfLine) when transitioning from "lf" to "auto" for better compatibility with Windows environments.

### Linked Issues
No linked issues

### Preview / Screenshot

<!-- Provide previews if any to give more illustrative context -->
![image](https://github.com/sozonome/nextarter-chakra/assets/50513707/3a007458-1ff9-4fa6-99cf-547134e4d821)

### Checklist

- [x] I have followed commit guideline to create PR title (https://conventionalcommits.org/en/v1.0.0/)
